### PR TITLE
chore: add ./idea folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -399,6 +399,7 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea/
 
 ##
 ## Visual studio for Mac


### PR DESCRIPTION
This update ensures that the `idea` folder is ignored by Git. It is useful for developers who work with JetBrains Rider IDE.